### PR TITLE
Adding save function as well as 'type' and 'length' props to Field

### DIFF
--- a/src/models/Field.js
+++ b/src/models/Field.js
@@ -1,7 +1,7 @@
 export default class Field {
   constructor (props) {
     if (typeof props === 'object') {
-      const requiredProps = ['name', 'uuid']
+      const requiredProps = ['name', 'uuid', 'type']
       requiredProps.map((prop, index) => {
         if (props.hasOwnProperty(prop)) {
           this[prop] = props[prop]
@@ -9,8 +9,17 @@ export default class Field {
           throw new Error('Error: Missing required property')
         }
       })
+      if (props.hasOwnProperty('length') && props.length > 0) {
+        this.length = props.length
+      } else {
+        // TODO: replace this with config settings
+        this.length = 37
+      }
     } else {
       throw new Error('Error: Expecting typeof Object')
     }
+  }
+  save () {
+    return JSON.stringify(this)
   }
 }

--- a/test/models/Field.spec.js
+++ b/test/models/Field.spec.js
@@ -13,10 +13,38 @@ describe('Class (Field)', () => {
       return testField
     }).to.throw(Error)
   })
+
   it('Should require a uuid property', () => {
     expect(() => {
-      let testField = new Field({name: 'My Test Field'})
+      let testField = new Field({name: 'Test Field'})
       return testField
     }).to.throw(Error)
+  })
+
+  it('Should require a type property', () => {
+    expect(() => {
+      let testField = new Field({name: 'Test Field', uuid: 'test_field'})
+      return testField
+    }).to.throw(Error)
+  })
+
+  it('Should set a length property if undefined', () => {
+    let props = {name: 'Test Field', uuid: 'test_field', type: 'type'}
+    let testField = new Field(props)
+    // TODO: replace this with config settings
+    let expectedLength = 37
+    expect(testField.length).to.equal(expectedLength)
+  })
+
+  it('Should set the length property to the provided value if passed', () => {
+    let props = {name: 'Test Field', uuid: 'test_field', type: 'test', length: 137}
+    let testField = new Field(props)
+    expect(testField.length).to.equal(137)
+  })
+
+  it('Should return a JSON string of the field settings', () => {
+    let props = {name: 'Test Field', uuid: 'test_field', type: 'test', length: 137}
+    let testField = new Field(props)
+    expect(testField.save()).to.equal(JSON.stringify(props))
   })
 })


### PR DESCRIPTION
Adding the `save()` function to the Field class to return a JSON string
that can be used when saving ContentType configurations to file. NOTE:
this function itself doesn't save the Field class attributes to file. I
also added the required constructor property of `type` that all Field
child classes must provide. There is also an optional 'length' prop that if not provided will default to the configuration default (right now it is set in code).